### PR TITLE
Update config.js

### DIFF
--- a/html/js/config.js
+++ b/html/js/config.js
@@ -19,7 +19,7 @@ var config = {
   feePerKB: new JSBigInt('10000000000'),//20^10 - for testnet its not used, as fee is dynamic.
   dustThreshold: new JSBigInt('2000000000'),//10^10 used for choosing outputs/change - we decompose all the way down if the receiver wants now regardless of threshold
   txChargeRatio: 0.5,
-  defaultMixin: 3, // minimum mixin for hardfork v5
+  defaultMixin: 5, // minimum mixin for hardfork v5
   txChargeAddress: 'XSwiLJUPxqv4hbFsvvV5BgVFqWiWmfzyXKWFQb9ZWuUJhKFhSYJUGSB6cmRn2qo2J5Vwsi1bfg8AYfyx9JKc2GdY2CiE1RrG8',
   idleTimeout: 30,
   idleWarningDuration: 20,


### PR DESCRIPTION
#3 moves the default mixins from 3 to 5 per v5 hard fork